### PR TITLE
Update deepin-topbar_es_ES.ts

### DIFF
--- a/translations/deepin-topbar_es_ES.ts
+++ b/translations/deepin-topbar_es_ES.ts
@@ -73,7 +73,7 @@
     <message>
         <location filename="../modules/indicator/View/systemlogo.cpp" line="86"/>
         <source>Logout for %1</source>
-        <translation>Salir de %1</translation>
+        <translation>Cerrar sesión de %1</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
the "Logout of% 1" line was translated into Spanish as Close session of% 1 to make it more understandable and adapts to the current translations of deepin into Spanish