### PR TITLE
Fit panel size to available screen geometry (exclude dock width)

### DIFF
--- a/frame/frame.pro
+++ b/frame/frame.pro
@@ -32,6 +32,7 @@ HEADERS  += \
     item/stretchitem.h \
     utils/itempopupwindow.h \
     utils/event_monitor.h \
+    utils/xcb_misc.h \
     item/contentmodule.h \
     utils/global.h \
     settings.h \
@@ -46,6 +47,7 @@ SOURCES += \
     item/stretchitem.cpp \
     utils/itempopupwindow.cpp \
     utils/event_monitor.cpp \
+    utils/xcb_misc.cpp \
     item/contentmodule.cpp \
     utils/global.cpp \
     settings.cpp \

--- a/frame/mainframe.cpp
+++ b/frame/mainframe.cpp
@@ -117,7 +117,7 @@ void MainFrame::showSetting()
 
 void MainFrame::setDocked(bool value)
 {
-    XcbMisc::instance()->set_window_type(winId(), value ? XcbMisc::Desktop : XcbMisc::Normal);
+    XcbMisc::instance()->set_window_type(winId(), value ? XcbMisc::Dock : XcbMisc::Normal);
 }
 
 void MainFrame::clearScreenGeometry()

--- a/frame/mainframe.h
+++ b/frame/mainframe.h
@@ -13,6 +13,8 @@
 
 #include "mainpanel.h"
 
+class DBusDock;
+
 DWIDGET_USE_NAMESPACE
 
 class MainFrame : public DBlurEffectWidget
@@ -30,11 +32,17 @@ private slots:
     void onWindowListChanged();
 //    void updateWindowListInfo();
     void onWindowStateChanged(Qt::WindowState windowState);
+    void delayedScreenChanged();
 
 private:
     void init();
     void initConnect();
     void initAnimation();
+
+    void setDocked(bool value);
+    void reserveScreenGeometry(int top, int startX, int endX);
+    void clearScreenGeometry();
+    void resizeWindow(bool hidden);
 
 private:
     QDesktopWidget *m_desktopWidget;
@@ -46,6 +54,8 @@ private:
     QMap<WId,DForeignWindow*> m_windowList;
     QList<WId> m_windowIdList;
     QList<WId> m_maxWindowList;
+
+    DBusDock *m_dockInter;
 };
 
 #endif // MAINFRAME_H

--- a/frame/utils/xcb_misc.cpp
+++ b/frame/utils/xcb_misc.cpp
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 Deepin Technology Co., Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ **/
+
+#include <QDebug>
+#include <QX11Info>
+#include <xcb/xcb.h>
+#include <xcb/xcb_ewmh.h>
+#include "xcb_misc.h"
+static XcbMisc * _xcb_misc_instance = NULL;
+XcbMisc::XcbMisc()
+{
+    xcb_intern_atom_cookie_t * cookie = xcb_ewmh_init_atoms(QX11Info::connection(), &m_ewmh_connection);
+    xcb_ewmh_init_atoms_replies(&m_ewmh_connection, cookie, NULL);
+}
+XcbMisc::~XcbMisc()
+{
+}
+XcbMisc * XcbMisc::instance()
+{
+    if (_xcb_misc_instance == NULL) {
+        _xcb_misc_instance = new XcbMisc;
+    }
+    return _xcb_misc_instance;
+}
+void XcbMisc::set_window_type(xcb_window_t winId, WindowType winType)
+{
+    xcb_atom_t atoms[1];
+    switch (winType) {
+    case WindowType::Desktop:
+        atoms[0] = m_ewmh_connection._NET_WM_WINDOW_TYPE_DESKTOP;
+        break;
+    case WindowType::Dock:
+        atoms[0] = m_ewmh_connection._NET_WM_WINDOW_TYPE_DOCK;
+        break;
+    case WindowType::Normal:
+        atoms[0] = m_ewmh_connection._NET_WM_WINDOW_TYPE_NORMAL;
+    default:
+        break;
+    }
+    xcb_ewmh_set_wm_window_type(&m_ewmh_connection, winId, 1, atoms);
+}
+void XcbMisc::set_strut_partial(xcb_window_t winId, Orientation orientation, uint strut, uint start, uint end)
+{
+    // xcb_ewmh_wm_strut_partial_t strut_partial is very different from
+    // xcb_ewmh_wm_strut_partial_t strut_partial {};
+    // the latter one ensures all its member to be initialized to 0;
+    xcb_ewmh_wm_strut_partial_t strut_partial {};
+    switch (orientation) {
+    case OrientationLeft:
+        strut_partial.left = strut;
+        strut_partial.left_start_y = start;
+        strut_partial.left_end_y = end;
+        break;
+    case OrientationRight:
+        strut_partial.right = strut;
+        strut_partial.right_start_y = start;
+        strut_partial.right_end_y = end;
+        break;
+    case OrientationTop:
+        strut_partial.top = strut;
+        strut_partial.top_start_x = start;
+        strut_partial.top_end_x = end;
+        break;
+    case OrientationBottom:
+        strut_partial.bottom = strut;
+        strut_partial.bottom_start_x = start;
+        strut_partial.bottom_end_x = end;
+        break;
+    default:
+        break;
+    }
+    xcb_ewmh_set_wm_strut_partial(&m_ewmh_connection, winId, strut_partial);
+}

--- a/frame/utils/xcb_misc.h
+++ b/frame/utils/xcb_misc.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Deepin Technology Co., Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ **/
+
+#ifndef XCB_MISC_H
+#define XCB_MISC_H
+#include <xcb/xcb_ewmh.h>
+class XcbMisc
+{
+public:
+    enum Orientation {
+        OrientationLeft,
+        OrientationRight,
+        OrientationTop,
+        OrientationBottom
+    };
+    enum WindowType {
+        Dock,
+        Desktop,
+        Normal
+    };
+    virtual ~XcbMisc();
+    static XcbMisc * instance();
+    void set_window_type(xcb_window_t winId, WindowType winType);
+    void set_strut_partial(xcb_window_t winId, Orientation orientation, uint strut, uint start, uint end);
+private:
+    XcbMisc();
+    xcb_ewmh_connection_t m_ewmh_connection;
+};
+#endif // XCB_MISC_H


### PR DESCRIPTION
Currently, when dock is on the left/right side or at the top, topbar will overlap the dock:

![Currently it is broken - dock and topbar overlaps](https://i.imgur.com/nOD5Y0A.png)

This PR fixes it - topbar now uses available geometry instead of whole screen geometry. It also detects dock settings changes and updates panel position according to it.

![Perfactly aligned dock and topbar after this commit](https://i.imgur.com/3lpDgwW.png)

It even properly aligns when dock is at the top (tho it doesn't make much sense then)

![Dock at the top](https://i.imgur.com/Q15jqK0.png)