### PR TITLE
Fix resizing topbar with fashion dock

### DIFF
--- a/frame/frame.pro
+++ b/frame/frame.pro
@@ -33,6 +33,7 @@ HEADERS  += \
     utils/itempopupwindow.h \
     utils/event_monitor.h \
     utils/xcb_misc.h \
+    utils/deepin_dock.h \
     item/contentmodule.h \
     utils/global.h \
     settings.h \

--- a/frame/mainframe.h
+++ b/frame/mainframe.h
@@ -33,6 +33,7 @@ private slots:
 //    void updateWindowListInfo();
     void onWindowStateChanged(Qt::WindowState windowState);
     void delayedScreenChanged();
+    void doubleDelayedScreenChanged();
 
 private:
     void init();
@@ -43,6 +44,7 @@ private:
     void reserveScreenGeometry(int top, int startX, int endX);
     void clearScreenGeometry();
     void resizeWindow(bool hidden);
+    QRect getScreenGeometry();
 
 private:
     QDesktopWidget *m_desktopWidget;
@@ -56,6 +58,9 @@ private:
     QList<WId> m_maxWindowList;
 
     DBusDock *m_dockInter;
+
+    bool isInDelayedScreenChanged;
+    QRect previousScreenRect;
 };
 
 #endif // MAINFRAME_H

--- a/frame/utils/deepin_dock.h
+++ b/frame/utils/deepin_dock.h
@@ -1,0 +1,19 @@
+#ifndef DEEPIN_DOCK_H
+#define DEEPIN_DOCK_H
+
+namespace Dock
+{
+   enum DockMode {
+        Fashion = 0,
+        Efficient = 1
+   };
+
+   enum Position {
+        Top = 0,
+        Right = 1,
+        Bottom = 2,
+        Left = 3
+   };
+};
+
+#endif


### PR DESCRIPTION
After last changes, there was a problem with resizing topbar with fashion dock, this is now special case - when dock is in fashion mode, whole screen geometry is taken instead (so that it looks good).

Also, there was a problem when dock was resizing too long - now it is done by double resizing - but only if it is needed (that's why there are nested timers, they will tho never intersects, as it checks if there is any other timer pending).

There is one bug now with changing dock size when dock stays on top - but as topbar with dock on top makes no sense, I think it can be skipped now.